### PR TITLE
Update CFG with expenses policy

### DIFF
--- a/cfg.html
+++ b/cfg.html
@@ -191,6 +191,12 @@
 
                     <p>
                         We would also welcome leads if you know of someone who could run a session. Please reach out to us at <a href="mailto:contact@codecraftuk.org">contact@codecraftuk.org</a>.
+                        
+                    <h2><b>Expenses policy</b></h2>
+                    
+                    <p>CodeCraftConf will reimburse any stationary and travel expenses incurred for guides coming on the day. But unfortunately, we cannot reimburse hotel costs.</p>
+
+                    <p>WWe are a non-profit conference and do not want to be a conference where presenters have to pay out of their pocket to speak. To avoid having guides pay for a hotel, we have a bias towards selecting people who can attend without needing to stay over in Glasgow.</p>
 
                         <h2 id="signup"><b>I'm up for it. Where do I sign up?</b></h2>
 


### PR DESCRIPTION
CodeCraftConf will reimburse any stationary and travel expenses incurred for guides coming on the day. But unfortunately cannot  reimburse hotel costs.

We are a non-profit conference and do not want to be a conference where presentors have to pay out of their own pocket to speak. To avoid having guides pay for a hotel we have a bias towards selecting people who can attend without needing to stay over in Glasgow.